### PR TITLE
Add config for optional server rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Below is the complete list of available options that can be used to customize yo
 | `CACHE_PUBLIC`            | `ico\|jpg\|jpeg\|png\|gif\|svg\|js\|jsx\|css\|less\|swf\|eot\|ttf\|otf\|woff\|woff2`                                        | Regular expression to specify which paths should be cachable (headers `Cache-Control` set to `public` and `Expires` set to the value of `$CACHE_PUBLIC_EXPIRATION`).                                                                                                                   |
 | `CACHE_PUBLIC_EXPIRATION` | `1y`                                                                                                         | Time to set for header `Expires`. See http://nginx.org/en/docs/http/ngx_http_headers_module.html#expires                                                                                                                                                                               |
 | `TRAILING_SLASH`          | `true`                                                                                                       | Specifies if paths should end with a trailing slash or not. Prevents [duplicated content](https://moz.com/learn/seo/duplicate-content) by redirecting requests to URLs ending with a slash to its non-trailing-slash equivalent if set to `true` and the other way around for `false`. |
+| `CUSTOM_SERVER_CONFIG`          | ` `                                                                                                       | Need to add some advanced/custom nginx config? No problem, you can inject through this environment variable. **NOTE:** would be discarded if `/etc/nginx/server.conf` is present. |
 | `DEBUG`                   | `false`                                                                                                      | If set to `true` the configuration is being printed before the server starts.                                                                                                                                                                                                          |
 
 ### Append rules for the server block in nginx config
@@ -74,3 +75,5 @@ Alternatively you can use a custom Dockerfile and copy the file on build:
   FROM gatsbyjs/gatsby:latest
   COPY nginx-server-rules.conf /etc/nginx/server.conf
   ```
+  
+**NOTE:** By adding the file `/etc/nginx/server.conf`, all the contents of the `CUSTOM_SERVER_CONFIG` environment variable will be discarded.

--- a/README.md
+++ b/README.md
@@ -59,3 +59,10 @@ Below is the complete list of available options that can be used to customize yo
 | `CACHE_PUBLIC_EXPIRATION` | `1y`                                                                                                         | Time to set for header `Expires`. See http://nginx.org/en/docs/http/ngx_http_headers_module.html#expires                                                                                                                                                                               |
 | `TRAILING_SLASH`          | `true`                                                                                                       | Specifies if paths should end with a trailing slash or not. Prevents [duplicated content](https://moz.com/learn/seo/duplicate-content) by redirecting requests to URLs ending with a slash to its non-trailing-slash equivalent if set to `true` and the other way around for `false`. |
 | `DEBUG`                   | `false`                                                                                                      | If set to `true` the configuration is being printed before the server starts.                                                                                                                                                                                                          |
+
+### Append rules for the server block in nginx config
+
+You can mount a file to `/etc/nginx/server.conf` to extend the server block in nginx config. This could be useful if you have defined client only routes in GatsbyJS. For example for client only rules on path `/client-only` the content of your mounted file should be like:
+```
+rewrite ^/client-only/([^.]*?/)$ /client-only/index.html;
+```

--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ Below is the complete list of available options that can be used to customize yo
 ### Append rules for the server block in nginx config
 
 You can mount a file to `/etc/nginx/server.conf` to extend the server block in nginx config. This could be useful if you have defined client only routes in GatsbyJS. For example for client only rules on path `/client-only` the content of your mounted file should be like:
-```
-rewrite ^/client-only/([^.]*?/)$ /client-only/index.html;
-```
+
+  ```
+  rewrite ^/client-only/([^.]*?/)$ /client-only/index.html;
+  ```
+
+Alternatively you can use a custom Dockerfile and copy the file on build:
+
+  ```Dockerfile
+  FROM gatsbyjs/gatsby:latest
+  COPY nginx-server-rules.conf /etc/nginx/server.conf
+  ```

--- a/nginx-boot.sh
+++ b/nginx-boot.sh
@@ -22,6 +22,12 @@ else
   REWRITE_RULE="rewrite ^([^.]*[^/])\$ \$1/ permanent"
 fi
 
+if [ -f /etc/nginx/server.conf ]; then
+  ADD_SERVER_RULES=$(</etc/nginx/server.conf)
+else
+  ADD_SERVER_RULES='';
+fi
+
 # Build config
 cat <<EOF > $NGINX_CONF
 daemon              off;
@@ -85,6 +91,8 @@ http {
     $REWRITE_RULE;
 
     try_files \$uri \$uri/ \$uri/index.html =404;
+
+    $ADD_SERVER_RULES
   }
 }
 

--- a/nginx-boot.sh
+++ b/nginx-boot.sh
@@ -23,9 +23,9 @@ else
 fi
 
 if [ -f /etc/nginx/server.conf ]; then
-  ADD_SERVER_RULES=$(</etc/nginx/server.conf)
+  CUSTOM_SERVER_CONFIG=$(</etc/nginx/server.conf)
 else
-  ADD_SERVER_RULES='';
+  CUSTOM_SERVER_CONFIG=${CUSTOM_SERVER_CONFIG:-};
 fi
 
 # Build config
@@ -92,7 +92,7 @@ http {
 
     try_files \$uri \$uri/ \$uri/index.html =404;
 
-    $ADD_SERVER_RULES
+    $CUSTOM_SERVER_CONFIG
   }
 }
 


### PR DESCRIPTION
If you define client only routes there is currently no possibility in the docker image to add these rewrite rules. With the proposed changes you can either mount a file that will append rules in the nginx server block or copy the file on build.

Furthermore you can use these option not only for rewrite rules but change other settings too.