### PR TITLE
Add development image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**/*
+!nginx-boot.sh
+!gatsby-boot.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script:
 # Lint
 - docker run -it --rm -v "$PWD/Dockerfile:/Dockerfile:ro" redcoolbeans/dockerlint
 - docker run -it --rm -v "$PWD/Dockerfile.onbuild:/Dockerfile:ro" redcoolbeans/dockerlint
+- docker run -it --rm -v "$PWD/Dockerfile.cli:/Dockerfile:ro" redcoolbeans/dockerlint
 
 env:
   global:
@@ -17,14 +18,17 @@ after_success:
   - export REPO=gatsbyjs/gatsby
   - export MAIN_TAG=`if [ "$TRAVIS_BRANCH" = "master" ]; then echo "latest"; else echo $TRAVIS_BRANCH ; fi`
   - export ONBUILD_TAG=`if [ "$TRAVIS_BRANCH" = "master" ]; then echo "onbuild"; else echo "$MAIN_TAG-onbuild" ; fi`
-  - echo "Main tag - $MAIN_TAG | Onbuild - $ONBUILD_TAG | Commit (shorten) - $COMMIT | Branch - $TRAVIS_BRANCH"
+  - export CLI_TAG=`if [ "$TRAVIS_BRANCH" = "master" ]; then echo "cli"; else echo "$MAIN_TAG-cli" ; fi`
+  - echo "Main - $MAIN_TAG | Onbuild - $ONBUILD_TAG | CLI - $CLI_TAG | Commit (shorten) - $COMMIT | Branch - $TRAVIS_BRANCH"
   - 
   - docker login -u $DOCKER_USER -p $DOCKER_PASS
 
 # Build and deploy
   - docker build -f Dockerfile -t $REPO:$COMMIT .
   - cat Dockerfile.onbuild | sed "s/gatsbyjs/gatsby:latest/$REPO:$COMMIT/" | docker build -t $REPO:$COMMIT-onbuild -
+  - docker build -t $REPO:$COMMIT-cli -f Dockerfile.cli .
   - docker tag $REPO:$COMMIT $REPO:$MAIN_TAG
   - docker tag $REPO:$COMMIT-onbuild $REPO:$ONBUILD_TAG
+  - docker tag $REPO:$COMMIT-cli $REPO:$CLI_TAG
 
   - docker push $REPO

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,29 +1,23 @@
 FROM node:10-alpine
 
-WORKDIR /gatsby
-
 ARG GATSBY_VERSION=^2.0.0
-ARG VIPS_VERSION=8.6.3-r0
 
-# Install dev dependencies
 RUN set -x \
-  && apk add --no-cache vips-dev=${VIPS_VERSION} \
-  --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+# Install dev dependencies
   && apk add --no-cache \
-  fftw-dev \
-  g++ \
   git \
+  g++ \
   make \
   python2 \
   binutils \
-  git
-
 # Install gatsby cli and cleanup
-RUN set -x \
   && npm install --global gatsby@${GATSBY_VERSION} \
-  --no-optional gatsby@${GATSBY_VERSION} \
   && npm cache clean --force
 
 COPY ./gatsby-boot.sh /sbin/gatsby-boot
+RUN chmod +x /sbin/gatsby-boot
+
+WORKDIR /site
+VOLUME /site
 
 ENTRYPOINT ["/sbin/gatsby-boot"]

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,0 +1,29 @@
+FROM node:10-alpine
+
+WORKDIR /gatsby
+
+ARG GATSBY_VERSION=^2.0.0
+ARG VIPS_VERSION=8.6.3-r0
+
+# Install dev dependencies
+RUN set -x \
+  && apk add --no-cache vips-dev=${VIPS_VERSION} \
+  --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+  && apk add --no-cache \
+  fftw-dev \
+  g++ \
+  git \
+  make \
+  python2 \
+  binutils \
+  git
+
+# Install gatsby cli and cleanup
+RUN set -x \
+  && npm install --global gatsby@${GATSBY_VERSION} \
+  --no-optional gatsby@${GATSBY_VERSION} \
+  && npm cache clean --force
+
+COPY ./gatsby-boot.sh /sbin/gatsby-boot
+
+ENTRYPOINT ["/sbin/gatsby-boot"]

--- a/gatsby-boot.sh
+++ b/gatsby-boot.sh
@@ -11,21 +11,24 @@ if [ ! -f "./package.json" ]; then
 	echo "Initializing Gatsby..."
 	gatsby new $GATSBY_WORKDIR
 	# Ensure packages are locked and up to date
-	npm install
+	yarn
 fi
 
 # Decide what to do
-if [ "$1" == "develop" ]; then
+if [ "$CMD" == "develop" ]; then
 	rm -rf ./public
 
 	shift
 	exec gatsby develop --host 0.0.0.0 --port $GATSBY_PORT $@
-elif [ "$1" == "build" ]; then
+elif [ "$CMD" == "build" ]; then
 	rm -rf ./public
 
 	shift
 	exec gatsby build $@
-elif [ "$1" == "stage" ]; then
+elif [ "$CMD" == "serve" ]; then
+	shift
+	exec gatsby serve --host 0.0.0.0 --port $GATSBY_PORT $@
+elif [ "$CMD" == "stage" ]; then
 	rm -rf ./public
 
 	shift
@@ -33,4 +36,5 @@ elif [ "$1" == "stage" ]; then
 	exec gatsby serve --host 0.0.0.0 --port $GATSBY_PORT $@
 fi
 
-exec $@
+# Or just exec
+exec gatsby $@

--- a/gatsby-boot.sh
+++ b/gatsby-boot.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-GATSBY_WORKDIR=${GATSBY_WORKDIR:-/gatsby}
+GATSBY_WORKDIR="/site"
 GATSBY_PORT=${GATSBY_PORT:-8000}
 
 cd "$GATSBY_WORKDIR"
@@ -9,26 +9,26 @@ cd "$GATSBY_WORKDIR"
 # Initialize Gatsby if no manifest found
 if [ ! -f "./package.json" ]; then
 	echo "Initializing Gatsby..."
-	gatsby new $GATSBY_WORKDIR
+	gatsby new .
 	# Ensure packages are locked and up to date
 	yarn
 fi
 
 # Decide what to do
-if [ "$CMD" == "develop" ]; then
+if [ "$1" == "develop" ]; then
 	rm -rf ./public
 
 	shift
 	exec gatsby develop --host 0.0.0.0 --port $GATSBY_PORT $@
-elif [ "$CMD" == "build" ]; then
+elif [ "$1" == "build" ]; then
 	rm -rf ./public
 
 	shift
 	exec gatsby build $@
-elif [ "$CMD" == "serve" ]; then
+elif [ "$1" == "serve" ]; then
 	shift
 	exec gatsby serve --host 0.0.0.0 --port $GATSBY_PORT $@
-elif [ "$CMD" == "stage" ]; then
+elif [ "$1" == "stage" ]; then
 	rm -rf ./public
 
 	shift

--- a/gatsby-boot.sh
+++ b/gatsby-boot.sh
@@ -36,5 +36,5 @@ elif [ "$1" == "stage" ]; then
 	exec gatsby serve --host 0.0.0.0 --port $GATSBY_PORT $@
 fi
 
-# Or just exec
-exec gatsby $@
+# Or just go through
+exec $@

--- a/gatsby-boot.sh
+++ b/gatsby-boot.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -e
+
+GATSBY_WORKDIR=${GATSBY_WORKDIR:-/gatsby}
+GATSBY_PORT=${GATSBY_PORT:-8000}
+
+cd "$GATSBY_WORKDIR"
+
+# Initialize Gatsby if no manifest found
+if [ ! -f "./package.json" ]; then
+	echo "Initializing Gatsby..."
+	gatsby new $GATSBY_WORKDIR
+	# Ensure packages are locked and up to date
+	npm install
+fi
+
+# Decide what to do
+if [ "$1" == "develop" ]; then
+	rm -rf ./public
+
+	shift
+	exec gatsby develop --host 0.0.0.0 --port $GATSBY_PORT $@
+elif [ "$1" == "build" ]; then
+	rm -rf ./public
+
+	shift
+	exec gatsby build $@
+elif [ "$1" == "stage" ]; then
+	rm -rf ./public
+
+	shift
+	gatsby build
+	exec gatsby serve --host 0.0.0.0 --port $GATSBY_PORT $@
+fi
+
+exec $@

--- a/gatsby-boot.sh
+++ b/gatsby-boot.sh
@@ -15,25 +15,25 @@ if [ ! -f "./package.json" ]; then
 fi
 
 # Decide what to do
-if [ "$1" == "develop" ]; then
+if [ "$1" = "develop" ]; then
 	rm -rf ./public
 
 	shift
-	exec gatsby develop --host 0.0.0.0 --port $GATSBY_PORT $@
-elif [ "$1" == "build" ]; then
+	exec gatsby develop --host 0.0.0.0 --port "$GATSBY_PORT" $@
+elif [ "$1" = "build" ]; then
 	rm -rf ./public
 
 	shift
 	exec gatsby build $@
-elif [ "$1" == "serve" ]; then
+elif [ "$1" = "serve" ]; then
 	shift
-	exec gatsby serve --host 0.0.0.0 --port $GATSBY_PORT $@
-elif [ "$1" == "stage" ]; then
+	exec gatsby serve --host 0.0.0.0 --port "$GATSBY_PORT" $@
+elif [ "$1" = "stage" ]; then
 	rm -rf ./public
 
 	shift
 	gatsby build
-	exec gatsby serve --host 0.0.0.0 --port $GATSBY_PORT $@
+	exec gatsby serve --host 0.0.0.0 --port "$GATSBY_PORT" $@
 fi
 
 # Or just go through


### PR DESCRIPTION
Closes #16 #11 

- Based on `node:10-alpine` 
- Configurable versions (build ARGs)
- Handy entrypoint script (initially based on [this one](https://github.com/aripalo/gatsby-docker/))

Build with: 
```sh
docker build -t gatsbyjs/cli -f Dockerfile.cli .
```

Works best with a volume:
```sh
mkdir -p gatsby-website
docker run -it --rm -p 8000:8000 \
	--user "$(id -u):$(id -g)" \
	-v $(pwd)/gatsby-website:/site \
	gatsbyjs/cli develop
```

User is specified to ensure it doesn't fucked up your files permission.

Supported commands:
- `develop` -> `gatsby develop`
- `build` -> `gatsby build`
- `serve` -> `gatsby serve`
- `stage` -> `gatsby build && gatsby serve`

These commands need to have wrappers because they don't support configuration of host and port via variables environments. Too bad :(

You can also use others commands of `gatsby` which does not need a wrapper (eg.: `repl`, `new`, `info`).

If a folder without `package.json` file is mounted on the `/site` dir, it will be provisioned with https://github.com/gatsbyjs/gatsby-starter-default.

