### PR TITLE
Improve Docker image

### DIFF
--- a/Dockerfile.onbuild
+++ b/Dockerfile.onbuild
@@ -1,6 +1,6 @@
-FROM node:10.15.3-stretch
+FROM node:10-stretch
 MAINTAINER José Moreira <josemoreiravarzim@gmail.com>
-RUN yarn global add gatsby-cli@2.4.17
+RUN yarn global add gatsby-cli
 ONBUILD WORKDIR /app
 ONBUILD ADD . ./
 ONBUILD RUN yarn

--- a/Dockerfile.onbuild
+++ b/Dockerfile.onbuild
@@ -1,7 +1,7 @@
 FROM node:10.15.3-stretch
 MAINTAINER José Moreira <josemoreiravarzim@gmail.com>
-RUN npm install -g gatsby-cli@2.4.17
+RUN yarn global add gatsby-cli@2.4.17
 ONBUILD WORKDIR /app
 ONBUILD ADD . ./
-ONBUILD RUN npm i
+ONBUILD RUN yarn
 ONBUILD RUN gatsby build

--- a/Dockerfile.onbuild
+++ b/Dockerfile.onbuild
@@ -1,4 +1,4 @@
-FROM node:10-stretch
+FROM node:12-buster
 MAINTAINER José Moreira <josemoreiravarzim@gmail.com>
 RUN yarn global add gatsby-cli
 ONBUILD WORKDIR /app

--- a/Dockerfile.onbuild
+++ b/Dockerfile.onbuild
@@ -2,5 +2,6 @@ FROM node:10.15.3-stretch
 MAINTAINER José Moreira <josemoreiravarzim@gmail.com>
 RUN npm install -g gatsby-cli@2.4.17
 ONBUILD WORKDIR /app
+ONBUILD ADD . ./
+ONBUILD RUN npm i
 ONBUILD RUN gatsby build
-ONBUILD ADD . .

--- a/Dockerfile.onbuild
+++ b/Dockerfile.onbuild
@@ -1,4 +1,6 @@
-FROM gatsbyjs/gatsby:latest
+FROM node:10.15.3-stretch
 MAINTAINER José Moreira <josemoreiravarzim@gmail.com>
-
-ONBUILD ADD public/ /pub
+RUN npm install -g gatsby-cli@2.4.17
+ONBUILD WORKDIR /app
+ONBUILD RUN gatsby build
+ONBUILD ADD . .

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This image has two major tags:
     COPY --from=build /app/public /pub
     ```
     _.dockerignore_
-    ```dockerfile
+    ```ignore
     .cache/
     node_modules/
     public/
@@ -36,8 +36,8 @@ This image has two major tags:
     ```
 1. Use it
     ```bash
-    docker run --rm -p 8080:80 myproject/website
-    # Open your browser at http://localhost:8080
+    docker run --rm -p 80:80 myproject/website
+    # Open your browser at http://localhost
     ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ This image has two major tags:
 1. Build your project's public assets with `gatsby build`
 1. Create a `Dockerfile`, as below, at the root of your project:
     ```dockerfile
-    FROM gatsbyjs/gatsby:onbuild
+    FROM gatsbyjs/gatsby:onbuild as build
+
+    FROM gatsbyjs/gatsby
+    COPY --from=build /pub /pub
     ```
 1. Build your project's docker image:
     ```bash
@@ -26,7 +29,7 @@ This image has two major tags:
     ```
 1. Use it
     ```bash
-    docker run --rm -p 80:80 myproject/website
+    docker run --rm -p 8080:80 myproject/website
     # Open your browser at http://localhost
     ```
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,21 @@ This image has two major tags:
 
 ## Usage
 
-1. Build your project's public assets with `gatsby build`
-1. Create a `Dockerfile`, as below, at the root of your project:
+1. Create at the root of your project a `Dockerfile` and `.dockerignore`, as below:
+    _Dockerfile_
     ```dockerfile
     FROM gatsbyjs/gatsby:onbuild as build
 
     FROM gatsbyjs/gatsby
-    COPY --from=build /pub /pub
+    COPY --from=build /app/public /pub
     ```
+    _.dockerignore_
+    ```dockerfile
+    .cache/
+    node_modules/
+    public/
+    ```
+    > The first image is going to copy your project, install dependencies and build it.
 1. Build your project's docker image:
     ```bash
     docker build -t myproject/website .
@@ -30,7 +37,7 @@ This image has two major tags:
 1. Use it
     ```bash
     docker run --rm -p 8080:80 myproject/website
-    # Open your browser at http://localhost
+    # Open your browser at http://localhost:8080
     ```
 
 ## Configuration


### PR DESCRIPTION
When im using Docker i like that i dont have to install anything else but Docker. I thought that it would be nice to build the project in `gatsbyjs/gatsby:onbuild` and then just copy the public dir to `gatsbyjs/gatsby`. Now as the documentation says the `:onbuild` tag builds the project and `:latest` serves it.
Also i first tried to use the image as the documentation but the `:onbuild` tag lacks of nginx rules and every request gets a `500`.
#25 