### PR TITLE
Apply Dockerfile best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM alpine:edge
 MAINTAINER José Moreira <josemoreiravarzim@gmail.com>
 
-ADD nginx-boot.sh /sbin/nginx-boot
+COPY nginx-boot.sh /sbin/nginx-boot
+RUN chmod +x /sbin/nginx-boot
 
-RUN chmod +x /sbin/nginx-boot && \
-    apk --update add nginx bash && \
+RUN apk --update add nginx bash && \
     rm -fR /var/cache/apk/*
 
 CMD [ "/sbin/nginx-boot" ]


### PR DESCRIPTION
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/

- use COPY instead of ADD
- split unrelated RUN instructions for better layer caching

Not really a functional change, but I believe it will make the Dockerfile more beginner friendly.