### PR TITLE
Issue #42: nginx config generated by nginx-boot.sh does bogus 301 red…

### DIFF
--- a/nginx-boot.sh
+++ b/nginx-boot.sh
@@ -58,7 +58,8 @@ http {
   keepalive_timeout  15;
   autoindex          off;
   server_tokens      off;
-  port_in_redirect   off;
+  port_in_redirect   on;
+  absolute_redirect  off;
   sendfile           off;
   tcp_nopush         on;
   tcp_nodelay        on;

--- a/nginx-boot.sh
+++ b/nginx-boot.sh
@@ -58,7 +58,7 @@ http {
   keepalive_timeout  15;
   autoindex          off;
   server_tokens      off;
-  port_in_redirect   on;
+  port_in_redirect   off;
   absolute_redirect  off;
   sendfile           off;
   tcp_nopush         on;


### PR DESCRIPTION
Fixes Issue #42.  

Modified nginx settings to enable correct redirects when using the -p argument in `docker run`.