### PR TITLE
feat(nginx): cache webp images

### DIFF
--- a/nginx-boot.sh
+++ b/nginx-boot.sh
@@ -13,7 +13,7 @@ export GZIP_TYPES=${GZIP_TYPES:-application/javascript application/x-javascript 
 export GZIP_LEVEL=${GZIP_LEVEL:-6}
 
 export CACHE_IGNORE=${CACHE_IGNORE:-html}
-export CACHE_PUBLIC=${CACHE_PUBLIC:-ico|jpg|jpeg|png|gif|svg|js|jsx|css|less|swf|eot|ttf|otf|woff|woff2}
+export CACHE_PUBLIC=${CACHE_PUBLIC:-ico|jpg|jpeg|png|gif|svg|webp|js|jsx|css|less|swf|eot|ttf|otf|woff|woff2}
 export CACHE_PUBLIC_EXPIRATION=${CACHE_PUBLIC_EXPIRATION:-1y}
 
 if [ "$TRAILING_SLASH" = false ]; then


### PR DESCRIPTION
Currently webp images generated by the update `gatsby-plugin-image` are not cached. This PR adds the files to the cache configuration


fix: #48