### PR TITLE
Update Dockerfile.onbuild

### DIFF
--- a/Dockerfile.onbuild
+++ b/Dockerfile.onbuild
@@ -1,4 +1,4 @@
-FROM node:12-buster
+FROM node:14-buster
 MAINTAINER José Moreira <josemoreiravarzim@gmail.com>
 RUN yarn global add gatsby-cli
 ONBUILD WORKDIR /app


### PR DESCRIPTION
Since some new features of Gatsby need 14.10, it seems about time to do this.